### PR TITLE
Adds get_content_formatter

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,4 @@
+choice-enum>=0.3.1
+django>=1.8,<1.11
 docutils
 markdown2>=2.3.1

--- a/transcode/conf.py
+++ b/transcode/conf.py
@@ -1,32 +1,57 @@
-HTML_FORMAT        = 'HTML' 
+# -*- coding: utf-8 -*-
+
+from collections import OrderedDict
+from django.conf import settings
+
+from choice_enum import Option, make_enum_class
+
+
+HTML_FORMAT        = 'HTML'
 SIMPLE_TEXT_FORMAT = 'TEXT'
 MARKDOWN_FORMAT    = 'MARK'
 RST_FORMAT         = 'REST'
 
-DEFAULT_CONFIG = {
-    HTML_FORMAT : {
-        'transcoder': 'transcode.render.render_html',
-        'kwargs': {},
-        'args': ()
-    },
-    SIMPLE_TEXT_FORMAT : {
+DEFAULT_CONFIG = OrderedDict((
+    (SIMPLE_TEXT_FORMAT, {
         'transcoder': 'transcode.render.render_simple',
+        'label': 'Simple text format',
+        'kwargs': {},
+        'args': (),
+        'default': True,
+    }),
+    (HTML_FORMAT, {
+        'transcoder': 'transcode.render.render_html',
+        'label': 'HTML format',
         'kwargs': {},
         'args': ()
-    },
-    MARKDOWN_FORMAT : {
+    }),
+    (MARKDOWN_FORMAT, {
         'transcoder': 'transcode.render.render_markdown',
+        'label': 'MarkDown format',
         'kwargs': {},
         'args': ()
-    },
-    RST_FORMAT : {
+    }),
+    (RST_FORMAT, {
         'transcoder': 'transcode.render.render_restructuredtext',
+        'label': 'ReStructured Text format',
         'kwargs': {},
         'args': ()
-    },
-}
+    }),
+))
 
 _config_db = {}
+
+
+def get_content_formatters(setting_name):
+    """
+    Fetches the provided setting and returns a choice_enum
+    """
+    formatters = getattr(settings, setting_name, DEFAULT_CONFIG)
+    choice_enum_kwargs = {
+        k: Option(k, v['label'], default=(v.get('default', False))) for k, v in
+        formatters.items()}
+    return make_enum_class('ContentFormat', **choice_enum_kwargs)
+
 
 def load_config(cfg=None):
     global _config_db


### PR DESCRIPTION
This method would be used in multiple projects, so, it makes sense to put it here instead. Also, by using the OrderedDict, we can control the order of the options where used.